### PR TITLE
Treat empty tables the same as non-empty tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Removed
 
 Fixed
 -----
-
+- Empty tables are now handled correctly.
 - Very large tables are now sorted without crashing. This is done by merge sorting
   in temporary files.
 
@@ -37,7 +37,7 @@ Added
 Added
 -----
 
-Document ``pg_incremental_backup.py`` in the README file
+- Document ``pg_incremental_backup.py`` in the README file
 
 
 0.9_ / 2015-03-10

--- a/pgtricks/pg_dump_splitsort.py
+++ b/pgtricks/pg_dump_splitsort.py
@@ -11,7 +11,7 @@ from typing import IO, Iterable, Match, Pattern, cast
 
 from pgtricks.mergesort import MergeSort
 
-COPY_RE = re.compile(r'COPY .*? \(.*?\) FROM stdin;\n$')
+COPY_RE = re.compile(r'COPY .*? FROM stdin;\n$')
 KIBIBYTE, MEBIBYTE, GIBIBYTE = 2**10, 2**20, 2**30
 MEMORY_UNITS = {"": 1, "k": KIBIBYTE, "m": MEBIBYTE, "g": GIBIBYTE}
 

--- a/pgtricks/pg_dump_splitsort.py
+++ b/pgtricks/pg_dump_splitsort.py
@@ -11,7 +11,7 @@ from typing import IO, Iterable, Match, Pattern, cast
 
 from pgtricks.mergesort import MergeSort
 
-COPY_RE = re.compile(r'COPY .*? FROM stdin;\n$')
+COPY_RE = re.compile(r"COPY\s+\S+\s+(\(.*?\)\s+)?FROM\s+stdin;\n$")
 KIBIBYTE, MEBIBYTE, GIBIBYTE = 2**10, 2**20, 2**30
 MEMORY_UNITS = {"": 1, "k": KIBIBYTE, "m": MEBIBYTE, "g": GIBIBYTE}
 


### PR DESCRIPTION
Currently there is a bug when there are empty tables added to the schema. The dump file then contains an empty COPY statement that is currently mishandled and causes the script to skip to count 9999