### PR TITLE
Remove double quotes from filenames

### DIFF
--- a/pgtricks/pg_split_schema_dump.py
+++ b/pgtricks/pg_split_schema_dump.py
@@ -64,7 +64,7 @@ def split_sql_file(sqlpath: str, target_directory: str) -> None:
             )
             print(part)
             continue
-        name = match.group(1).replace(" ", "_")
+        name = match.group(1).replace(" ", "_").replace('"', '')
         type_ = match.group(2).replace(" ", "_")
         schema = match.group(3)
         if schema == "-":

--- a/pgtricks/pg_split_schema_dump.py
+++ b/pgtricks/pg_split_schema_dump.py
@@ -64,7 +64,7 @@ def split_sql_file(sqlpath: str, target_directory: str) -> None:
             )
             print(part)
             continue
-        name = match.group(1).replace(" ", "_").replace('"', '')
+        name = match.group(1).replace(" ", "_").replace('"', "")
         type_ = match.group(2).replace(" ", "_")
         schema = match.group(3)
         if schema == "-":

--- a/pgtricks/tests/test_pg_split_schema_dump.py
+++ b/pgtricks/tests/test_pg_split_schema_dump.py
@@ -152,36 +152,37 @@ def test_split_sql_file_unrecognized_content(tmpdir):
         ============================================================================="""
     )
 
+
 def test_split_sql_file_with_quotes_in_name(tmpdir):
-    target_directory = tmpdir / 'target'
-    sqlpath = tmpdir / 'test.sql'
+    target_directory = tmpdir / "target"
+    sqlpath = tmpdir / "test.sql"
     sqlpath.write(
         dedent(
-            '''
+            """
 
             --
             -- Name: "user"; Type: TABLE; Schema: public; Owner:
             --
 
             (information for user table goes here)
-            '''
+            """
         )
     )
 
     split_sql_file(str(sqlpath), str(target_directory))
 
     assert {path.basename for path in target_directory.listdir()} == {
-        'public.user.TABLE'
+        "public.user.TABLE"
     }
-    assert (target_directory / 'public.user.TABLE').readlines(cr=False) == [
-        'SET search_path = public;',
-        '',
-        '',
-        '',
-        '--',
+    assert (target_directory / "public.user.TABLE").readlines(cr=False) == [
+        "SET search_path = public;",
+        "",
+        "",
+        "",
+        "--",
         '-- Name: "user"; Type: TABLE; Schema: public; Owner:',
-        '--',
-        '',
-        '(information for user table goes here)',
-        '',
+        "--",
+        "",
+        "(information for user table goes here)",
+        "",
     ]

--- a/pgtricks/tests/test_pg_split_schema_dump.py
+++ b/pgtricks/tests/test_pg_split_schema_dump.py
@@ -151,3 +151,37 @@ def test_split_sql_file_unrecognized_content(tmpdir):
         (information for the unidentified content goes here)
         ============================================================================="""
     )
+
+def test_split_sql_file_with_quotes_in_name(tmpdir):
+    target_directory = tmpdir / 'target'
+    sqlpath = tmpdir / 'test.sql'
+    sqlpath.write(
+        dedent(
+            '''
+
+            --
+            -- Name: "user"; Type: TABLE; Schema: public; Owner:
+            --
+
+            (information for user table goes here)
+            '''
+        )
+    )
+
+    split_sql_file(str(sqlpath), str(target_directory))
+
+    assert {path.basename for path in target_directory.listdir()} == {
+        'public.user.TABLE'
+    }
+    assert (target_directory / 'public.user.TABLE').readlines(cr=False) == [
+        'SET search_path = public;',
+        '',
+        '',
+        '',
+        '--',
+        '-- Name: "user"; Type: TABLE; Schema: public; Owner:',
+        '--',
+        '',
+        '(information for user table goes here)',
+        '',
+    ]


### PR DESCRIPTION
This pull request addresses an issue with table names that include double quotes. 

Previously, the `split_sql_file` function in `pg_split_schema_dump.py` would generate filenames that included double quotes if the table name in the SQL dump file was double-quoted (using a reserved keyword as table name, for example 'user'). This could cause an error when trying to write the file, as double quotes are not allowed in filenames on Windows. Example:

`OSError: [Errno 22] Invalid argument: '.\\split-dump\\my_schema.TABLE_"user".ACL'`

The change in this pull request modifies the `split_sql_file` function to remove double quotes from table names when generating filenames, and adds a test case.